### PR TITLE
! Switch to gauge for JVM memory metrics

### DIFF
--- a/src/main/scala/kamon/instrumentation/system/jvm/JvmMetrics.scala
+++ b/src/main/scala/kamon/instrumentation/system/jvm/JvmMetrics.scala
@@ -22,13 +22,13 @@ object JvmMetrics {
     unit = MeasurementUnit.information.bytes
   )
 
-  val MemoryUsed = Kamon.histogram (
+  val MemoryUsed = Kamon.gauge (
     name = "jvm.memory.used",
     description = "Samples the used space in a memory region",
     unit = MeasurementUnit.information.bytes
   )
 
-  val MemoryFree = Kamon.histogram (
+  val MemoryFree = Kamon.gauge (
     name = "jvm.memory.free",
     description = "Samples the free space in a memory region",
     unit = MeasurementUnit.information.bytes
@@ -46,13 +46,13 @@ object JvmMetrics {
     unit = MeasurementUnit.information.bytes
   )
 
-  val MemoryPoolUsed = Kamon.histogram (
+  val MemoryPoolUsed = Kamon.gauge (
     name = "jvm.memory.pool.used",
     description = "Samples the used space in a memory pool",
     unit = MeasurementUnit.information.bytes
   )
 
-  val MemoryPoolFree = Kamon.histogram (
+  val MemoryPoolFree = Kamon.gauge (
     name = "jvm.memory.pool.free",
     description = "Samples the free space in a memory pool",
     unit = MeasurementUnit.information.bytes
@@ -146,8 +146,8 @@ object JvmMetrics {
   object MemoryUsageInstruments {
 
     case class MemoryRegionInstruments (
-      used: Histogram,
-      free: Histogram,
+      used: Gauge,
+      free: Gauge,
       committed: Gauge,
       max: Gauge
     )

--- a/src/main/scala/kamon/instrumentation/system/jvm/JvmMetricsCollector.scala
+++ b/src/main/scala/kamon/instrumentation/system/jvm/JvmMetricsCollector.scala
@@ -14,7 +14,7 @@ import kamon.instrumentation.system.jvm.JvmMetricsCollector.{Collector, MemoryPo
 import kamon.module.{Module, ModuleFactory}
 import kamon.tag.TagSet
 
-import scala.collection.JavaConverters.{collectionAsScalaIterableConverter, mapAsScalaMapConverter}
+import scala.jdk.CollectionConverters._
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.util.matching.Regex
@@ -120,15 +120,15 @@ class JvmMetricsCollector(ec: ExecutionContext) extends Module {
 
       val currentHeapUsage = ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
       val freeHeap = Math.max(0L, currentHeapUsage.getMax -  currentHeapUsage.getUsed)
-      _heapUsage.free.record(freeHeap)
-      _heapUsage.used.record(currentHeapUsage.getUsed)
+      _heapUsage.free.update(freeHeap)
+      _heapUsage.used.update(currentHeapUsage.getUsed)
       _heapUsage.max.update(currentHeapUsage.getMax)
       _heapUsage.committed.update(currentHeapUsage.getCommitted)
 
       val currentNonHeapUsage = ManagementFactory.getMemoryMXBean.getNonHeapMemoryUsage
       val freeNonHeap = Math.max(0L, currentNonHeapUsage.getMax -  currentNonHeapUsage.getUsed)
-      _nonHeapUsage.free.record(freeNonHeap)
-      _nonHeapUsage.used.record(currentNonHeapUsage.getUsed)
+      _nonHeapUsage.free.update(freeNonHeap)
+      _nonHeapUsage.used.update(currentNonHeapUsage.getUsed)
       _nonHeapUsage.max.update(currentNonHeapUsage.getMax)
       _nonHeapUsage.committed.update(currentNonHeapUsage.getCommitted)
 
@@ -137,8 +137,8 @@ class JvmMetricsCollector(ec: ExecutionContext) extends Module {
         val memoryUsage = memoryBean.getUsage
         val freeMemory = Math.max(0L, memoryUsage.getMax -  memoryUsage.getUsed)
 
-        poolInstruments.free.record(freeMemory)
-        poolInstruments.used.record(memoryUsage.getUsed)
+        poolInstruments.free.update(freeMemory)
+        poolInstruments.used.update(memoryUsage.getUsed)
         poolInstruments.max.update(memoryUsage.getMax)
         poolInstruments.committed.update(memoryUsage.getCommitted)
       })

--- a/src/main/scala/kamon/instrumentation/system/process/ProcessMetricsCollector.scala
+++ b/src/main/scala/kamon/instrumentation/system/process/ProcessMetricsCollector.scala
@@ -13,7 +13,7 @@ import kamon.Kamon
 import oshi.SystemInfo
 import oshi.util.{FileUtil, ParseUtil}
 
-import scala.collection.JavaConverters.iterableAsScalaIterableConverter
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 


### PR DESCRIPTION
README.md states that JVM memory metrics are recorded using a gauge, but
the actual implementation uses a histogram. A histogram is not suitable
for this kind of metric, as the distribution of allocated memory is
typically of little interest, and long-term average memory consumption is
not a particular meaningful metric.

By switching to gauges for JVM memory metrics, it will be possible to
read the latest memory usage of an application which is more useful
for monitoring.

[prometheus-output-before.txt](https://github.com/kamon-io/kamon-system-metrics/files/2113997/prometheus-output-before.txt)
[prometheus-output-after.txt](https://github.com/kamon-io/kamon-system-metrics/files/2113998/prometheus-output-after.txt)