### PR TITLE
Add multiple sigar native folder locations to keep in line with kamon-io/sigar-loader

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -31,6 +31,8 @@ kamon {
 
       # Sigar provisioner native library extract location. Use per-application-instance scoped location, such as program
       # working directory.
+      sigar-native-folder = ${?KAMON_SIGAR_FOLDER}
+      sigar-native-folder = ${?kamon.sigar.folder}
       sigar-native-folder = ${user.dir}"/native"
 
       # Frequency with which context-switches metrics will be updated.


### PR DESCRIPTION
Currently only loading sigar from the `${user.dir}/native` but sigar-loader checks other locations first, so this PR helps keep both projects in line.

Should help with issue https://github.com/kamon-io/sigar-loader/issues/4