### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ kamon {
    # sigar is enabled by default
    host.enabled = true
 
-   # jmx related metrics are enabled by default
-   jmx.enabled = true
+   # jvm related metrics are enabled by default
+   jvm.enabled = true
   }
 }
 ```


### PR DESCRIPTION
Nitpick on the README shows wrong configuration for enabling jvm metrics.
The code looks at
https://github.com/kamon-io/kamon-system-metrics/blob/master/src/main/scala/kamon/system/SystemMetrics.scala#L63
